### PR TITLE
Avoid CDN self-signed cert

### DIFF
--- a/signalstickers_client/urls.py
+++ b/signalstickers_client/urls.py
@@ -1,5 +1,5 @@
 
-CDN_BASEURL = "https://cdn.signal.org/"
+CDN_BASEURL = "https://cdn-ca.signal.org/"
 
 CDN_STICKER_URL = CDN_BASEURL + "stickers/{pack_id}/"
 CDN_MANIFEST_URL = CDN_STICKER_URL + "manifest.proto"


### PR DESCRIPTION
https://cdn.signal.org now uses a self signed cert. This is a lazy fix because Adhesive is broken and I need something quicker than figuring out how to do proper cert pinning.