### PR TITLE
Use anyio >3.0.0

### DIFF
--- a/examples/download_stickers.py
+++ b/examples/download_stickers.py
@@ -26,7 +26,7 @@ async def main():
         # Saves all stickers in webp format in /tmp/stickersclient in parallel
         # if the directory exists
         for sticker in pack.stickers:
-            await tg.spawn(save_sticker, sticker)
+            tg.start_soon(save_sticker, sticker)
 
 if __name__ == '__main__':
     anyio.run(main)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'anyio>=2.0.2,<3.0.0',
-        'httpx>=0.16.1,<0.17.0',
+        'httpx>=0.16.1',
         'cryptography>=3.1.1,<4.0.0',
         'protobuf>=3.13.0,<4.0.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'anyio>=2.0.2,<3.0.0',
-        'httpx>=0.16.1',
+        'httpx>=0.16.1,<=0.24.1',
         'cryptography>=3.1.1,<4.0.0',
         'protobuf>=3.13.0,<4.0.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/romainricard/signalstickers-client",
     packages=setuptools.find_packages(),
     install_requires=[
-        'anyio>=2.0.2,<3.0.0',
+        'anyio>=2.0.2',
         'httpx>=0.16.1,<=0.24.1',
         'cryptography>=3.1.1,<4.0.0',
         'protobuf>=3.13.0,<4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/romainricard/signalstickers-client",
     packages=setuptools.find_packages(),
     install_requires=[
-        'anyio>=2.0.2',
+        'anyio>=3.0.0,<4.0.0',
         'httpx>=0.16.1,<=0.24.1',
         'cryptography>=3.1.1,<4.0.0',
         'protobuf>=3.13.0,<4.0.0',

--- a/signalstickers_client/classes/downloader.py
+++ b/signalstickers_client/classes/downloader.py
@@ -24,9 +24,9 @@ async def get_pack(http: httpx.AsyncClient, pack_id, pack_key):
     async with anyio.create_task_group() as tg:
         # The StickerPack object is created, but stickers and cover
         # are still missing the raw_image
-        await tg.spawn(get_sticker_image, pack.cover)
+        tg.start_soon(get_sticker_image, pack.cover)
         for sticker in pack.stickers:
-            await tg.spawn(get_sticker_image, sticker)
+            tg.start_soon(get_sticker_image, sticker)
 
     return pack
 

--- a/signalstickers_client/classes/uploader.py
+++ b/signalstickers_client/classes/uploader.py
@@ -69,7 +69,7 @@ async def upload_pack(http, pack, signal_user, signal_password):
                     iv=iv
                 )
 
-                await tg.spawn(_upload_cdn, http, pack_attrs["stickers"][sticker.id], encrypted_sticker)
+                tg.start_soon(_upload_cdn, http, pack_attrs["stickers"][sticker.id], encrypted_sticker)
 
     return pack_attrs["packId"], pack_key
 


### PR DESCRIPTION
This PR upgrades anyio to >3.0.0. To do so, httpx also has to be upgraded.

Upgrading anyio to >3.0.0 allows this package to work with other packages that use anyio >3.0.0 such as `python-telegram-bot`.