### PR TITLE
Remove upper limit of dependencies version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setuptools.setup(
     url="https://github.com/romainricard/signalstickers-client",
     packages=setuptools.find_packages(),
     install_requires=[
-        'anyio>=3.0.0,<4.0.0',
-        'httpx>=0.16.1,<=0.24.1',
-        'cryptography>=3.1.1,<4.0.0',
-        'protobuf>=3.13.0,<4.0.0',
+        'anyio>=3.0.0',
+        'httpx>=0.16.1',
+        'cryptography>=3.1.1',
+        'protobuf>=3.13.0',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
For a library, it is bad practice to to set upper limit of dependencies' version.

Everytime a new python version is released and library releases new version, things break and we have to wait for signalstickers-client to remove the version restriction (https://github.com/signalstickers/signalstickers-client/issues/21)

You may argue that the dependency may release a new major version that break signalstickers-client, but this could still be temporarily mitigated by the user by specifying the dependency version themselves in `requirements.txt`.

However, if signalstickers-client add upper bound to library version and a dependency release a new version that is actually compatible, the only way for the user to install signalstickers-client with newer version of dependency is git clone this repo, change dependency version requirement in `setup.py` themselves and pip install. Also note that if the user of this library do this, they cannot publish their library to PyPI as the dependency of a library on PyPI cannot be a git repo (Gets rejected during wheel upload).

This article discuss about this problem: https://iscinumpy.dev/post/bound-version-constraints/

This PR removes upper limit on dependencies' version.