### PR TITLE
Improve typing

### DIFF
--- a/examples/download_stickers.py
+++ b/examples/download_stickers.py
@@ -1,6 +1,7 @@
 import os
 import anyio
 from signalstickers_client import StickersClient
+from signalstickers_client.models import Sticker
 
 
 async def main():
@@ -15,12 +16,12 @@ async def main():
     print(pack.author)  # "Bits of Freedom"
     print(pack.nb_stickers)  # 7
 
-    async def save_sticker(sticker):
+    async def save_sticker(sticker: Sticker):
         async with await anyio.open_file(
             os.path.join("/tmp", "stickersclient", "{}.webp".format(sticker.id)),
             "wb",
         ) as f:
-            await f.write(sticker.image_data)
+            await f.write(sticker.image_data)  # type: ignore
 
     async with anyio.create_task_group() as tg:
         # Saves all stickers in webp format in /tmp/stickersclient in parallel

--- a/examples/merge_packs.py
+++ b/examples/merge_packs.py
@@ -34,10 +34,10 @@ async def main():
             if sticker.image_data:  # Sometimes, stickers are HTTP 403 for... reasons
                 nb_stickers += 1
                 new_stick = Sticker()
-                new_stick.id = sticker.id + id_offset
+                new_stick.id = sticker.id + id_offset  # type: ignore
                 new_stick.emoji = sticker.emoji
                 new_stick.image_data = sticker.image_data
-                new_pack._addsticker(new_stick)
+                new_pack._addsticker(new_stick)  # type: ignore
 
         id_offset += nb_stickers
 

--- a/examples/upload_stickers.py
+++ b/examples/upload_stickers.py
@@ -6,7 +6,7 @@ from signalstickers_client.models import LocalStickerPack, Sticker
 
 
 async def main():
-    def add_sticker(path, emoji):
+    def add_sticker(path: str, emoji: str):
 
         stick = Sticker()
         stick.id = pack.nb_stickers
@@ -15,7 +15,7 @@ async def main():
         with open(path, "rb") as f_in:
             stick.image_data = f_in.read()
 
-        pack._addsticker(stick)
+        pack._addsticker(stick)  # type: ignore
 
 
     pack = LocalStickerPack()

--- a/signalstickers_client/__init__.py
+++ b/signalstickers_client/__init__.py
@@ -1,2 +1,2 @@
-from .stickersclient import StickersClient
+from .stickersclient import StickersClient  # type: ignore
 from .errors import *

--- a/signalstickers_client/classes/Stickers_pb2.pyi
+++ b/signalstickers_client/classes/Stickers_pb2.pyi
@@ -1,0 +1,17 @@
+from typing import Iterator, Protocol
+
+from signalstickers_client.models.sticker import Sticker
+
+class StickersList(Protocol):
+    def add(self) -> Sticker: ...
+    def __iter__(self) -> Iterator[Sticker]: ...
+    def __next__(self) -> Sticker: ...
+
+class Pack:
+    title: str
+    author: str
+    cover: Sticker
+    stickers: StickersList
+
+    def ParseFromString(self, data: bytes) -> None: ...
+    def SerializeToString(self) -> bytes: ...

--- a/signalstickers_client/classes/downloader.py
+++ b/signalstickers_client/classes/downloader.py
@@ -1,6 +1,7 @@
 """
 This module allows to get full sticker packs, contains both data and metadata
 """
+
 from typing import Optional
 
 import anyio
@@ -32,7 +33,9 @@ async def get_pack(http: httpx.AsyncClient, pack_id: str, pack_key: str) -> Stic
     return pack
 
 
-async def get_pack_metadata(http: httpx.AsyncClient, pack_id: str, pack_key: str) -> StickerPack:
+async def get_pack_metadata(
+    http: httpx.AsyncClient, pack_id: str, pack_key: str
+) -> StickerPack:
     """
     Parse the pack manifest, and return
     a `StickerPack` object
@@ -71,7 +74,9 @@ async def get_pack_metadata(http: httpx.AsyncClient, pack_id: str, pack_key: str
     return pack
 
 
-async def get_sticker(http: httpx.AsyncClient, sticker_id: Optional[int], pack_id: str, pack_key: str):
+async def get_sticker(
+    http: httpx.AsyncClient, sticker_id: Optional[int], pack_id: str, pack_key: str
+):
     """
     Return the content of the webp file for a given sticker
     """

--- a/signalstickers_client/classes/downloader.py
+++ b/signalstickers_client/classes/downloader.py
@@ -1,6 +1,7 @@
 """
 This module allows to get full sticker packs, contains both data and metadata
 """
+from typing import Optional
 
 import anyio
 import httpx
@@ -12,13 +13,13 @@ from signalstickers_client.classes.Stickers_pb2 import Pack
 from signalstickers_client.errors import HTTPException, NotFound
 
 
-async def get_pack(http: httpx.AsyncClient, pack_id, pack_key):
+async def get_pack(http: httpx.AsyncClient, pack_id: str, pack_key: str) -> StickerPack:
     """
     Return a `StickerPack` and all of its enclosing `Sticker` images from its id and key
     """
     pack = await get_pack_metadata(http, pack_id, pack_key)
 
-    async def get_sticker_image(sticker):
+    async def get_sticker_image(sticker: Sticker):
         sticker.image_data = await get_sticker(http, sticker.id, pack_id, pack_key)
 
     async with anyio.create_task_group() as tg:
@@ -31,7 +32,7 @@ async def get_pack(http: httpx.AsyncClient, pack_id, pack_key):
     return pack
 
 
-async def get_pack_metadata(http, pack_id, pack_key):
+async def get_pack_metadata(http: httpx.AsyncClient, pack_id: str, pack_key: str) -> StickerPack:
     """
     Parse the pack manifest, and return
     a `StickerPack` object
@@ -65,12 +66,12 @@ async def get_pack_metadata(http, pack_id, pack_key):
         sticker = Sticker()
         sticker.id = pb_sticker.id
         sticker.emoji = pb_sticker.emoji
-        pack._addsticker(sticker)
+        pack._addsticker(sticker)  # type: ignore
 
     return pack
 
 
-async def get_sticker(http, sticker_id, pack_id, pack_key):
+async def get_sticker(http: httpx.AsyncClient, sticker_id: Optional[int], pack_id: str, pack_key: str):
     """
     Return the content of the webp file for a given sticker
     """

--- a/signalstickers_client/classes/signalcrypto.py
+++ b/signalstickers_client/classes/signalcrypto.py
@@ -1,16 +1,18 @@
+from secrets import token_bytes
+from typing import Tuple
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac, padding
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from secrets import token_bytes
 
 # Signal encrypted {sticker, manifest} are composed as follow:
 #   iv (16) + encrypted data (n) + hmac (32)
 
 
-def encrypt(plaintext, aes_key, hmac_key):
+def encrypt(plaintext: bytes, aes_key: bytes, hmac_key: bytes) -> bytes:
     """
     Encrypt a manifest or an image
     """
@@ -32,7 +34,7 @@ def encrypt(plaintext, aes_key, hmac_key):
     return iv + encrypted_data + hmac_o.finalize()
 
 
-def decrypt(encrypted_data, pack_key):
+def decrypt(encrypted_data: bytes, pack_key: str) -> bytes:
     """
     Decrypt a manifest or an image
     """
@@ -59,7 +61,7 @@ def decrypt(encrypted_data, pack_key):
     return unpadded_data + unpadder.finalize()
 
 
-def derive_key(pack_key):
+def derive_key(pack_key: str) -> Tuple[bytes, bytes]:
     """
     Derive a pack_key, and returns a `aes_key` and a `hmac_key`
     """

--- a/signalstickers_client/classes/uploader.py
+++ b/signalstickers_client/classes/uploader.py
@@ -11,11 +11,11 @@ from signalstickers_client.urls import SERVICE_STICKER_FORM_URL, CDN_BASEURL
 
 
 async def upload_pack(
-        http: httpx.AsyncClient,
-        pack: LocalStickerPack,
-        signal_user: str,
-        signal_password: str,
-    ) -> Tuple[str, str]:
+    http: httpx.AsyncClient,
+    pack: LocalStickerPack,
+    signal_user: str,
+    signal_password: str,
+) -> Tuple[str, str]:
     """
     Upload a pack, and return (pack_id, pack_key)
     """
@@ -88,10 +88,10 @@ async def upload_pack(
 
 
 async def _upload_cdn(
-        http: httpx.AsyncClient,
-        cdn_creds: Dict[str, str],
-        encrypted_data: bytes,
-    ):
+    http: httpx.AsyncClient,
+    cdn_creds: Dict[str, str],
+    encrypted_data: bytes,
+):
     """
     Upload an object (manifest or sticker) to the CDN
     """

--- a/signalstickers_client/classes/uploader.py
+++ b/signalstickers_client/classes/uploader.py
@@ -1,13 +1,21 @@
+import httpx
 from secrets import token_hex
+from typing import Dict, Tuple
 
 import anyio
 
 from signalstickers_client.classes.signalcrypto import encrypt, derive_key
-from signalstickers_client.urls import SERVICE_STICKER_FORM_URL, CDN_BASEURL
 from signalstickers_client.errors import HTTPException, Unauthorized, RateLimited
+from signalstickers_client.models import LocalStickerPack
+from signalstickers_client.urls import SERVICE_STICKER_FORM_URL, CDN_BASEURL
 
 
-async def upload_pack(http, pack, signal_user, signal_password):
+async def upload_pack(
+        http: httpx.AsyncClient,
+        pack: LocalStickerPack,
+        signal_user: str,
+        signal_password: str,
+    ) -> Tuple[str, str]:
     """
     Upload a pack, and return (pack_id, pack_key)
     """
@@ -64,7 +72,7 @@ async def upload_pack(http, pack, signal_user, signal_password):
             for sticker in stickers_list[i : i + 5]:
                 # Encrypt the sticker
                 encrypted_sticker = encrypt(
-                    plaintext=sticker.image_data,
+                    plaintext=sticker.image_data,  # type: ignore
                     aes_key=aes_key,
                     hmac_key=hmac_key,
                 )
@@ -79,7 +87,11 @@ async def upload_pack(http, pack, signal_user, signal_password):
     return pack_attrs["packId"], pack_key
 
 
-async def _upload_cdn(http, cdn_creds, encrypted_data):
+async def _upload_cdn(
+        http: httpx.AsyncClient,
+        cdn_creds: Dict[str, str],
+        encrypted_data: bytes,
+    ):
     """
     Upload an object (manifest or sticker) to the CDN
     """

--- a/signalstickers_client/errors.py
+++ b/signalstickers_client/errors.py
@@ -1,3 +1,5 @@
+from httpx import Response
+
 class SignalException(Exception):
     """Base class for all exceptions explicitly raised by this library."""
 
@@ -5,7 +7,7 @@ class SignalException(Exception):
 class HTTPException(SignalException):
     """Base class for all exceptions caused by HTTP errors"""
 
-    def __init__(self, response, message):
+    def __init__(self, response: Response, message: str):
         self.response = response
         self.status_code = response.status_code
         super().__init__(f"{response.status_code}: {message}")

--- a/signalstickers_client/errors.py
+++ b/signalstickers_client/errors.py
@@ -1,5 +1,6 @@
 from httpx import Response
 
+
 class SignalException(Exception):
     """Base class for all exceptions explicitly raised by this library."""
 

--- a/signalstickers_client/models/__init__.py
+++ b/signalstickers_client/models/__init__.py
@@ -3,8 +3,4 @@ from .sticker import Sticker
 from .sticker_pack import StickerPack
 
 
-__all__ = (
-    "LocalStickerPack",
-    "Sticker",
-    "StickerPack"
-)
+__all__ = ("LocalStickerPack", "Sticker", "StickerPack")

--- a/signalstickers_client/models/local_sticker_pack.py
+++ b/signalstickers_client/models/local_sticker_pack.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from typing import List, Optional
 
 import signalstickers_client.classes.Stickers_pb2 as protobuf_stickers
+from signalstickers_client.models.sticker import Sticker
 
 
 class LocalStickerPack:
@@ -11,29 +13,31 @@ class LocalStickerPack:
     """
 
     def __init__(self):
-        self.title = None
-        self.author = None
-        self.stickers = []
-        self.cover = None
+        self.title: Optional[str] = None
+        self.author: Optional[str] = None
+        self.stickers: List[Sticker] = []
+        self.cover: Optional[Sticker] = None
 
     @property
-    def nb_stickers(self):
+    def nb_stickers(self) -> int:
         """
         Return the number of stickers in the pack
         """
         return len(self.stickers)
 
     @property
-    def nb_stickers_with_cover(self):
+    def nb_stickers_with_cover(self) -> int:
         """
         Return the number of stickers in the pack, including the cover
         """
         return len(self.stickers) + 1 if self.cover else len(self.stickers)
 
     @property
-    def manifest(self):
+    def manifest(self) -> bytes:
         manifest = protobuf_stickers.Pack()
+        assert self.title
         manifest.title = self.title
+        assert self.author
         manifest.author = self.author
 
         cover = manifest.cover
@@ -52,7 +56,7 @@ class LocalStickerPack:
 
         return manifest.SerializeToString()
 
-    def _addsticker(self, sticker):
+    def _addsticker(self, sticker: Sticker) -> None:
         """
         Add the binary content (which is a webp image) to
         the `StickerPack`' list of stickers

--- a/signalstickers_client/models/sticker.py
+++ b/signalstickers_client/models/sticker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from typing import Optional
 
 
 class Sticker:
@@ -8,6 +9,6 @@ class Sticker:
     """
 
     def __init__(self):
-        self.id = None
-        self.emoji = None
-        self.image_data = None
+        self.id: Optional[int] = None
+        self.emoji: Optional[str] = None
+        self.image_data: Optional[bytes] = None

--- a/signalstickers_client/models/sticker_pack.py
+++ b/signalstickers_client/models/sticker_pack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from typing import List, Optional
+
+from signalstickers_client.models.sticker import Sticker
 
 
 class StickerPack:
@@ -7,13 +10,13 @@ class StickerPack:
     Represent a Sticker Pack
     """
 
-    def __init__(self, id, key):
-        self.id = id
-        self.key = key
-        self.title = None
-        self.author = None
-        self.cover = None
-        self.stickers = []
+    def __init__(self, id: str, key: str):
+        self.id: str = id
+        self.key: str = key
+        self.title: Optional[str] = None
+        self.author: Optional[str] = None
+        self.cover: Optional[Sticker] = None
+        self.stickers: List[Sticker] = []
 
     @property
     def nb_stickers(self):
@@ -22,7 +25,7 @@ class StickerPack:
         """
         return len(self.stickers)
 
-    def _addsticker(self, sticker):
+    def _addsticker(self, sticker: Sticker):
         """
         Add the binary content (which is a webp image) to
         the `StickerPack`' list of stickers

--- a/signalstickers_client/stickersclient.py
+++ b/signalstickers_client/stickersclient.py
@@ -26,6 +26,7 @@
     License: LGPLv3
 """
 import httpx
+from types import TracebackType
 
 from signalstickers_client.classes import downloader, uploader
 from signalstickers_client.models import LocalStickerPack
@@ -33,7 +34,7 @@ from signalstickers_client.utils.ca import CACERT_PATH
 
 
 class StickersClient:
-    def __init__(self, signal_user="", signal_pass=""):
+    def __init__(self, signal_user: str = "", signal_pass: str = "") -> None:
         self.http: httpx.AsyncClient
         self.signal_user = signal_user
         self.signal_pass = signal_pass
@@ -42,22 +43,27 @@ class StickersClient:
         self.http = await httpx.AsyncClient(verify=CACERT_PATH).__aenter__()
         return self
 
-    async def __aexit__(self, *excinfo):
-        return await self.http.__aexit__(*excinfo)
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        return await self.http.__aexit__(exc_type, exc_value, traceback)
 
-    async def get_pack(self, pack_id, pack_key):
+    async def get_pack(self, pack_id: str, pack_key: str):
         """
         Return a `StickerPack` from its id and key
         """
         return await downloader.get_pack(self.http, pack_id, pack_key)
 
-    async def get_pack_metadata(self, pack_id, pack_key):
+    async def get_pack_metadata(self, pack_id: str, pack_key: str):
         """
         Same as `.get_pack` but doesn't fetch the individual sticker images.
         """
         return await downloader.get_pack_metadata(self.http, pack_id, pack_key)
 
-    async def download_sticker(self, sticker_id: int, pack_id, pack_key) -> bytes:
+    async def download_sticker(self, sticker_id: int, pack_id: str, pack_key: str) -> bytes:
         """
         Return the image data for a given `sticker_id` belonging to the given `pack_id` and `pack_key`
         """

--- a/signalstickers_client/stickersclient.py
+++ b/signalstickers_client/stickersclient.py
@@ -25,6 +25,7 @@
     Author: Romain RICARD <contact+stickerclient@romainricard.fr>
     License: LGPLv3
 """
+
 import httpx
 from types import TracebackType
 
@@ -63,7 +64,9 @@ class StickersClient:
         """
         return await downloader.get_pack_metadata(self.http, pack_id, pack_key)
 
-    async def download_sticker(self, sticker_id: int, pack_id: str, pack_key: str) -> bytes:
+    async def download_sticker(
+        self, sticker_id: int, pack_id: str, pack_key: str
+    ) -> bytes:
         """
         Return the image data for a given `sticker_id` belonging to the given `pack_id` and `pack_key`
         """

--- a/signalstickers_client/urls.py
+++ b/signalstickers_client/urls.py
@@ -1,8 +1,8 @@
 CDN_BASEURL = "https://cdn.signal.org/"
 
-CDN_STICKER_URL = CDN_BASEURL + "stickers/{pack_id}/"
-CDN_MANIFEST_URL = CDN_STICKER_URL + "manifest.proto"
-CDN_STICKER_URL = CDN_STICKER_URL + "full/{sticker_id}"
+CDN_STICKER_URL_BASE = CDN_BASEURL + "stickers/{pack_id}/"
+CDN_MANIFEST_URL = CDN_STICKER_URL_BASE + "manifest.proto"
+CDN_STICKER_URL = CDN_STICKER_URL_BASE + "full/{sticker_id}"
 
 SERVICE_BASEURL = "https://chat.signal.org"
 SERVICE_STICKER_FORM_URL = SERVICE_BASEURL + "/v1/sticker/pack/form/{nb_stickers}"

--- a/signalstickers_client/utils/ca/__init__.py
+++ b/signalstickers_client/utils/ca/__init__.py
@@ -1,1 +1,1 @@
-from .ca import CACERT_PATH
+from .ca import CACERT_PATH  # type: ignore

--- a/tests/mock_httpx.py
+++ b/tests/mock_httpx.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from os.path import join, dirname
 
 
-def get_data_from_url(url):
+def get_data_from_url(url: str):
     """
     Depending on the URL, returns the bin data of the requested file
     """
@@ -30,7 +32,7 @@ class MockResponse:
 
     status_code = 200
 
-    def __init__(self, url):
+    def __init__(self, url: str):
         self.content_data = get_data_from_url(url)
 
     @property
@@ -44,17 +46,17 @@ class MockHttpx:
     """
 
     @staticmethod
-    def __init__(*args, **kwargs):
+    def __init__(*args: Any, **kwargs: Any):
         pass
 
     @staticmethod
-    async def __aenter__(*args, **kwargs):
+    async def __aenter__(*args: Any, **kwargs: Any):
         return MockHttpx
 
     @staticmethod
-    async def __aexit__(*args, **kwargs):
+    async def __aexit__(*args: Any, **kwargs: Any):
         pass
 
     @staticmethod
-    async def get(*args, **kwargs):
+    async def get(*args: Any, **kwargs: Any):
         return MockResponse(url=args[0])

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,12 +10,12 @@ from mock_httpx import MockHttpx
 pytestmark = pytest.mark.anyio
 
 
-def test_download(monkeypatch):
+def test_download(monkeypatch: pytest.MonkeyPatch):
     """
     With a mocked httpx lib, test the whole "download" part.
     """
 
-    async def get_pack(pack_id, pack_key):
+    async def get_pack(pack_id: str, pack_key: str):
         async with signalstickers_client.StickersClient() as client:
             pack = await client.get_pack(pack_id, pack_key)
             return pack
@@ -53,6 +53,8 @@ def test_download(monkeypatch):
 
     # Check stickers
     for sticker in pack.stickers:
+        assert sticker.id is not None
+        assert sticker.image_data is not None
         assert (
             expected_files[sticker.id]["hash"]
             == hashlib.sha256(sticker.image_data).hexdigest()
@@ -60,6 +62,8 @@ def test_download(monkeypatch):
         assert expected_files[sticker.id]["emoji"] == sticker.emoji
 
     # Check cover
+    assert pack.cover
+    assert pack.cover.image_data
     assert (
         expected_files["cover"]["hash"]
         == hashlib.sha256(pack.cover.image_data).hexdigest()


### PR DESCRIPTION
This PR improves type hints for this library. The library should now pass a strict type checker without error (Except for the automatically generated `Stickers_pb2.py`, which I have added a pyi stub file for it)